### PR TITLE
Handle selection of one or more employers

### DIFF
--- a/CRM/Contactlayout/Form/Inline/ProfileBlock.php
+++ b/CRM/Contactlayout/Form/Inline/ProfileBlock.php
@@ -44,18 +44,32 @@ class CRM_Contactlayout_Form_Inline_ProfileBlock extends CRM_Profile_Form_Edit {
       $cidElement->freeze();
       $cidElement->setValue($this->_id);
     }
+
+    // Special handling for employer
+    if ($this->elementExists('current_employer')) {
+      $employerField = $this->getElement('current_employer');
+      $employerField = $this->addEntityRef('current_employer', $employerField->getLabel(), [
+        'create' => TRUE,
+        'multiple' => TRUE,
+        'api' => ['params' => ['contact_type' => 'Organization']],
+      ]);
+      $employers = self::getEmployers($this->_id);
+      $employerField->setValue(array_column($employers, 'contact_id'));
+    }
   }
 
   /**
    * Save profiles
    *
-   * @throws \CiviCRM_API3_Exception
+   * @throws CiviCRM_API3_Exception
    */
   public function postProcess() {
     $values = $this->exportValues();
+    // Ignore value from contact id field
     unset($values['id']);
     $values['contact_id'] = $cid = $this->_id;
     $values['profile_id'] = $this->_gid;
+    $this->processEmployer($values);
     $result = civicrm_api3('Profile', 'submit', $values);
 
     // These are normally performed by CRM_Contact_Form_Inline postprocessing but this form doesn't inherit from that class.
@@ -68,6 +82,84 @@ class CRM_Contactlayout_Form_Inline_ProfileBlock extends CRM_Profile_Form_Edit {
       $this->ajaxResponse,
       CRM_Contact_Form_Inline_Lock::getResponse($cid)
     );
+    // Refresh tabs affected by this profile
+    foreach (['tag', 'group', 'note'] as $tab) {
+      if (isset($values[$tab])) {
+        $this->ajaxResponse['updateTabs']["#tab_$tab"] = CRM_Contact_BAO_Contact::getCountComponent($tab, $this->_id);
+      }
+    }
+  }
+
+  /**
+   * @param int $cid
+   * @return array
+   * @throws \API_Exception
+   */
+  public static function getEmployers($cid) {
+    $relationships = Civi\Api4\Relationship::get()
+      ->setSelect(['contact_id_b', 'contact_b.display_name'])
+      ->setCheckPermissions(FALSE)
+      ->addWhere('is_active', '=', '1')
+      ->addWhere('contact_id_a', '=', $cid)
+      ->addWhere('relationship_type.name_a_b', '=', 'Employee of')
+      ->addClause('OR', ['start_date', 'IS NULL'], ['start_date', '<=', 'now'])
+      ->addClause('OR', ['end_date', 'IS NULL'], ['end_date', '>', 'now'])
+      ->execute();
+    $results = [];
+    foreach ($relationships as $relationship) {
+      $results[] = [
+        'id' => $relationship['id'],
+        'contact_id' => $relationship['contact_id_b'],
+        'display_name' => $relationship['contact_b']['display_name'],
+      ];
+    }
+    return $results;
+  }
+
+  /**
+   * Handles setting one or more employers for a contact.
+   *
+   * @param $values
+   * @throws \API_Exception
+   */
+  public function processEmployer(&$values) {
+    if (isset($values['current_employer'])) {
+      if (is_string($values['current_employer'])) {
+        $values['current_employer'] = $values['current_employer'] ? explode(',', $values['current_employer']) : [];
+      }
+      $existingEmployers = array_column(self::getEmployers($this->_id), 'contact_id', 'id');
+      foreach ($existingEmployers as $id => $employer) {
+        if (!in_array($employer, $values['current_employer'])) {
+          Civi\Api4\Relationship::update()
+            ->addWhere('id', '=', $id)
+            ->setCheckPermissions(FALSE)
+            ->addValue('is_active', '0')
+            ->execute();
+        }
+      }
+      $employerRelationshipType = Civi\Api4\RelationshipType::get()
+        ->setSelect(["id"])
+        ->addWhere("name_a_b", "=", "Employee of")
+        ->execute()
+        ->first()['id'];
+      foreach (array_values($values['current_employer']) as $i => $employer) {
+        if (!in_array($employer, $existingEmployers)) {
+          Civi\Api4\Relationship::create()
+            ->setCheckPermissions(FALSE)
+            ->addValue('relationship_type_id', $employerRelationshipType)
+            ->addValue('contact_id_a', $this->_id)
+            ->addValue('contact_id_b', $employer)
+            ->execute();
+        }
+        // Set first org as "current employer" since CiviCRM only allows one
+        if (!$i) {
+          CRM_Contact_BAO_Contact_Utils::setCurrentEmployer([$this->_id => $employer]);
+        }
+      }
+      // Refresh relationship tab
+      $this->ajaxResponse['updateTabs']['#tab_rel'] = CRM_Contact_BAO_Contact::getCountComponent('rel', $this->_id);
+      unset($values['current_employer']);
+    }
   }
 
 }

--- a/CRM/Contactlayout/Page/Inline/ProfileBlock.php
+++ b/CRM/Contactlayout/Page/Inline/ProfileBlock.php
@@ -31,9 +31,21 @@ class CRM_Contactlayout_Page_Inline_ProfileBlock extends CRM_Core_Page {
     }
     CRM_Core_BAO_UFGroup::getValues($contactId, $fields, $values, FALSE);
     $result = [];
-    foreach ($fields as $fieldName => $field) {
+    foreach ($fields as $name => $field) {
+      // Special handling for employer field
+      if ($name == 'current_employer') {
+        $employers = [];
+        foreach (CRM_Contactlayout_Form_Inline_ProfileBlock::getEmployers($contactId) as $employer) {
+          $org = $employer['display_name'];
+          if (CRM_Contact_BAO_Contact_Permission::allow($employer['contact_id'])) {
+            $org = '<a href="' . CRM_Utils_System::url('civicrm/contact/view', ['reset' => 1, 'cid' => $employer['contact_id']]) . '" title="' . E::ts('view employer') . '">' . $org . '</a>';
+          }
+          $employers[] = $org;
+        }
+        $values[$field['title']] = implode(', ', $employers);
+      }
       $result[] = [
-        'name' => $fieldName,
+        'name' => $name,
         'value' => CRM_Utils_Array::value($field['title'], $values),
         'label' => $field['title'],
       ];

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Have you ever wanted to rearrange the contact summary screen? Move the most impo
 
 ## Requirements
 
-* CiviCRM 5.5+
+* CiviCRM 5.6+
 * [Api v4 extension](https://github.com/civicrm/org.civicrm.api4)
 * [Angular Profiles extension](https://github.com/ginkgostreet/org.civicrm.angularprofiles)
 * (Optional) Looks best with a bootstrap-based admin theme or the [Shoreditch exension](https://github.com/civicrm/org.civicrm.shoreditch).

--- a/info.xml
+++ b/info.xml
@@ -18,7 +18,7 @@
   <version>1.0</version>
   <develStage>stable</develStage>
   <compatibility>
-    <ver>5.5</ver>
+    <ver>5.6</ver>
   </compatibility>
   <comments>Looks best with a bootstrap theme such as Shoreditch.</comments>
   <requires>

--- a/templates/CRM/Contactlayout/Page/Inline/ProfileBlock.tpl
+++ b/templates/CRM/Contactlayout/Page/Inline/ProfileBlock.tpl
@@ -8,7 +8,7 @@
     {foreach from=$profileBlock item='profileRow'}
       <div class="crm-summary-row">
         <div class="crm-label">{$profileRow.label|escape}</div>
-        <div class="crm-content">{$profileRow.value|escape}</div>
+        <div class="crm-content">{$profileRow.value|purify}</div>
       </div>
     {/foreach}
   </div>


### PR DESCRIPTION
Fixes #22 
Now you can pick one or more employers as the "Current employer"

Now this extension actually handles the field better than core :/
We should port this functionality to core at some point, but probably will want to do one more step and have the "current employer" and "organization name" fields be serialized.