### PR TITLE
Add support for 'Groups' profile field

### DIFF
--- a/CRM/Contactlayout/Page/Inline/ProfileBlock.php
+++ b/CRM/Contactlayout/Page/Inline/ProfileBlock.php
@@ -32,6 +32,11 @@ class CRM_Contactlayout_Page_Inline_ProfileBlock extends CRM_Core_Page {
     CRM_Core_BAO_UFGroup::getValues($contactId, $fields, $values, FALSE);
     $result = [];
     foreach ($fields as $name => $field) {
+      // Special handling for group field (profiles only show public groups by default)
+      if ($name == 'group') {
+        $groups = array_column(CRM_Contact_BAO_GroupContact::getContactGroup($contactId, 'Added'), 'title');
+        $values[$field['title']] = implode(', ', $groups);
+      }
       // Special handling for employer field
       if ($name == 'current_employer') {
         $employers = [];

--- a/templates/CRM/Contactlayout/Form/Inline/ProfileBlock.tpl
+++ b/templates/CRM/Contactlayout/Form/Inline/ProfileBlock.tpl
@@ -61,7 +61,7 @@
             {/if}
             {if $n eq 'email_greeting' or  $n eq 'postal_greeting' or $n eq 'addressee'}
               {include file="CRM/Profile/Form/GreetingType.tpl"}
-            {elseif ( $n eq 'group' && $form.group ) || ( $n eq 'tag' && $form.tag )}
+            {elseif ( $n eq 'tag' && $form.tag )}
               {include file="CRM/Contact/Form/Edit/TagsAndGroups.tpl" type=$n context="profile" tableLayout=1}
             {elseif ( $form.$n.name eq 'image_URL' )}
               {$form.$n.html}


### PR DESCRIPTION
This allows the "Groups" field to function as one would expect it to.

Because profiles handle groups so oddly (with all kinds of assumptions about the form being front-end-facing and requiring double-opt-in, etc) I opted to override the whole kaboodle in this extension.

Depends on https://github.com/civicrm/org.civicrm.api4/pull/95