### PR TITLE
Refresh related blocks

### DIFF
--- a/CRM/Contactlayout/Page/Inline/ProfileBlock.php
+++ b/CRM/Contactlayout/Page/Inline/ProfileBlock.php
@@ -9,7 +9,13 @@ class CRM_Contactlayout_Page_Inline_ProfileBlock extends CRM_Core_Page {
 
     $this->assign('contactId', $contactId);
     $this->assign('profileBlock', self::getProfileBlock($profileId, $contactId));
-    $this->assign('block', ['profile_id' => $profileId]);
+
+    $allBlocks = CRM_Contactlayout_BAO_ContactLayout::getAllBlocks();
+    foreach ($allBlocks['profile']['blocks'] as $block) {
+      if ($block['profile_id'] == $profileId) {
+        $this->assign('block', $block);
+      }
+    }
 
     // Needed to display tags
     $this->assign('contactTag', CRM_Core_BAO_EntityTag::getContactTags($contactId));

--- a/templates/CRM/Contactlayout/Page/Inline/ProfileBlock.tpl
+++ b/templates/CRM/Contactlayout/Page/Inline/ProfileBlock.tpl
@@ -1,4 +1,4 @@
-<div {if $permission EQ 'edit'} class="crm-inline-edit" data-edit-params='{ldelim}"cid": "{$contactId}", "gid": {$block.profile_id}, "class_name": "CRM_Contactlayout_Form_Inline_ProfileBlock"{rdelim}' {/if}>
+<div id="{$block.selector|replace:'#':''}" {if $permission EQ 'edit'} class="crm-inline-edit" data-dependent-fields={$block.refresh|@json_encode} data-edit-params='{ldelim}"cid": "{$contactId}", "gid": {$block.profile_id}, "class_name": "CRM_Contactlayout_Form_Inline_ProfileBlock"{rdelim}' {/if}>
   <div class="crm-clear crm-inline-block-content" {if $permission EQ 'edit'}title="{ts}Edit{/ts}"{/if}>
     {if $permission EQ 'edit'}
       <div class="crm-edit-help">


### PR DESCRIPTION
This makes the ajax more seamless when using profile-based blocks.
For example now if you add a "first name" and "last name" field to the profile and edit the block, the contact name at the top of the screen will update.