### PR TITLE
Disable/hide blocks for the wrong contact type

### DIFF
--- a/ang/contactlayout.css
+++ b/ang/contactlayout.css
@@ -225,6 +225,13 @@
   font-size: 12px;
   font-weight: 500;
 }
+#cse-block-container #cse-palette .invalid-block {
+  cursor: not-allowed;
+}
+#cse-block-container #cse-palette .invalid-block h5 {
+  color: grey;
+  text-decoration: line-through;
+}
 #cse-block-container .cse-layout-col .block-multiple:not(.collapsed) {
   margin-bottom: 40px;
 }

--- a/ang/contactlayout/contactlayout.html
+++ b/ang/contactlayout/contactlayout.html
@@ -60,7 +60,7 @@
                 <form class="navbar-form navbar-left">
                   <div class="form-group">
                     <label for="selected_layout_contact_type">{{ ts('Show:') }}</label>
-                    <select id="selected_layout_contact_type" class="form-control" ng-model="selectedLayout.contact_type" crm-ui-select ng-change="clearSubType(selectedLayout)">
+                    <select id="selected_layout_contact_type" class="form-control" ng-model="selectedLayout.contact_type" crm-ui-select ng-change="changeContactType(selectedLayout)">
                       <option value="">{{ ts('Contact type') }}</option>
                       <option ng-repeat="ct in contactTypes" value="{{ ct.name }}" ng-if="!ct.parent_id">{{ ct.label }}</option>
                     </select>
@@ -92,8 +92,8 @@
                       </button>
                     </div>
                   </h4>
-                  <div id="cse-palette" class="cse-col" ui-sortable="{connectWith: '.cse-col', containment: '#cse-block-container', update: enforceUnique}" ng-model="selectedLayout.palette">
-                    <div class="cse-block" ng-repeat="block in selectedLayout.palette" ng-include="'~/contactlayout/contactlayoutblock.html'"></div>
+                  <div id="cse-palette" class="cse-col" ui-sortable="{connectWith: '.cse-col', containment: '#cse-block-container', update: enforceUnique, cancel: 'input,textarea,button,select,option,a,.invalid-block'}" ng-model="selectedLayout.palette">
+                    <div class="cse-block" ng-repeat="block in selectedLayout.palette" ng-class="{'invalid-block': selectedLayout.contact_type && block.contact_type && selectedLayout.contact_type !== block.contact_type}" ng-include="'~/contactlayout/contactlayoutblock.html'"></div>
                   </div>
                 </div>
               </div>

--- a/ang/contactlayout/contactlayout.js
+++ b/ang/contactlayout/contactlayout.js
@@ -15,10 +15,13 @@
             return crmApi4({
               layouts: ['ContactLayout', 'get', {orderBy: {weight: 'ASC'}}],
               blocks:  ['ContactLayout', 'getBlocks'],
-              contactTypes: ['ContactType', 'get'],
+              contactTypes: ['ContactType', 'get', {
+                where: [['is_active','=','1']],
+                orderBy: {label: 'ASC'}
+              }],
               groups: ['Group', 'get', {
                 select: ['name','title','description'],
-                where: [['is_hidden','=','0'],['is_active','=','1'],['saved_search_id','IS NULL','']]
+                where: [['is_hidden','=','0'], ['is_active','=','1'], ['saved_search_id','IS NULL','']]
               }]
             });
           }
@@ -69,8 +72,20 @@
       return ts('All contact types');
     };
 
-    $scope.clearSubType = function(layout) {
+    $scope.contactTypeLabel = function(contactType) {
+      return getLabels(contactType, data.contactTypes);
+    };
+
+    $scope.changeContactType = function(layout) {
       layout.contact_sub_type = null;
+      if (layout.contact_type) {
+        _.each(layout.blocks, function(blocks, i) {
+          layout.blocks[i] = _.filter(blocks, function(block) {
+            return !block.contact_type || block.contact_type === layout.contact_type;
+          });
+        });
+        loadLayout(layout);
+      }
     };
 
     $scope.showGroups = function(layout) {

--- a/ang/contactlayout/contactlayoutblock.html
+++ b/ang/contactlayout/contactlayoutblock.html
@@ -1,4 +1,4 @@
-<h5 title="{{ ts('%1 block', {1: block.groupTitle || 'Unknown'}) }}">
+<h5 title="{{ ts('%1 block', {1: block.groupTitle || 'Unknown'}) + (block.contact_type ? ' (' + contactTypeLabel(block.contact_type) + ')' : '') }}">
   <i class="crm-i {{ block.icon || 'fa-question-circle-o' }}"></i>
   <span ng-if="!col || (!block.collapsible && !block.showTitle)">{{ block.title || ts('Untitled') }}</span>
   <span ng-if="col && (block.collapsible || block.showTitle)" contact-layout-editable ng-model="block.title">{{ block.title || ts('Untitled') }}</span>


### PR DESCRIPTION
Hides blocks on summary page not applicable to contact type being viewed.
Also prevents blocks being added to a layout of the wrong contact type.

Fixes #30 
Fixes #15

![screenshot from 2018-09-19 12-14-24](https://user-images.githubusercontent.com/2874912/45766488-ba39ab00-bc05-11e8-867c-7a6e8bc0dae8.png)
