### PR TITLE
Add flexibility to display content from URL 

### DIFF
--- a/templates/CRM/Contact/Page/View/SummaryHook.tpl
+++ b/templates/CRM/Contact/Page/View/SummaryHook.tpl
@@ -10,7 +10,11 @@
               </div>
             {/if}
             <div class="crm-summary-block">
-              {include file=$block.tpl_file}
+              {if $block.tpl_file}
+                {include file=$block.tpl_file}
+              {elseif $block.content_url}
+                {fetch file=$block.content_url}
+              {/if}
             </div>
           </div>
         {/foreach}


### PR DESCRIPTION
We're trying to load view dashlet created by https://www.drupal.org/project/civicrm_views_dashlets into contact summary page and seem the hook `contactSummaryBlocks` provided by this extension almost does it for us.

But, it looks like each display need to have a tpl file to display the content on the block rendered on the page. Can we have it extended to also permit URL contents if we don't have a tpl file created?

Hook written to add view dashlets to the page is -

    function viewdashletlayout_civicrm_contactSummaryBlocks(&$blocks) {
      // Register our block with the layout editor.
      $dashlets = civicrm_api3('Dashboard', 'get', array(
        'name' => array('LIKE' => '%dashlet_view%'),
        'options' => array('limit' => 0),
      ));
      if (empty($dashlets['count'])) {
        return;
      }
      foreach ($dashlets['values'] as $key => $dashlet) {
        $blocks['core']['blocks'][$dashlet['name']] = [
          'title' => $dashlet['label'],
          'collapsible' => TRUE,
          'showTitle' => TRUE,
          'content_url' => CRM_Utils_System::url($dashlet['url'], NULL, TRUE),
          'edit' => FALSE,
        ];
      }
    }
