### PR TITLE
Use custom group icons if available

### DIFF
--- a/CRM/Contactlayout/BAO/ContactLayout.php
+++ b/CRM/Contactlayout/BAO/ContactLayout.php
@@ -384,7 +384,7 @@ class CRM_Contactlayout_BAO_ContactLayout extends CRM_Contactlayout_DAO_ContactL
         'id' => "custom_{$group['id']}",
         'title' => $group['title'],
         'weight' => $weight += 10,
-        'icon' => 'crm-i fa-gear',
+        'icon' => 'crm-i ' . ($group['icon'] ?? 'fa-gear'),
         'contact_type' => $group['extends'] == 'Contact' ? NULL : $group['extends'],
       ];
     }


### PR DESCRIPTION
This makes use of custom group icons, if available, per https://github.com/civicrm/civicrm-core/pull/17531