### PR TITLE
CATL-1529: Support for relationships between different contact types

### DIFF
--- a/CRM/Contactlayout/BAO/ContactLayout.php
+++ b/CRM/Contactlayout/BAO/ContactLayout.php
@@ -69,7 +69,13 @@ class CRM_Contactlayout_BAO_ContactLayout extends CRM_Contactlayout_DAO_ContactL
         foreach ($row as &$column) {
           foreach ($column as &$block) {
             $blockInfo = self::getBlock($block['name']);
-            if ($blockInfo && (!$contactType || empty($blockInfo['contact_type']) || $contactType == $blockInfo['contact_type'])) {
+            $isValidBlock = self::checkBlockValidity(
+              $blockInfo,
+              $block['related_rel'],
+              $contactType
+            );
+
+            if ($isValidBlock) {
               $block += $blockInfo;
             }
             // Invalid or missing block
@@ -117,6 +123,65 @@ class CRM_Contactlayout_BAO_ContactLayout extends CRM_Contactlayout_DAO_ContactL
       }
     }
     return NULL;
+  }
+
+  /**
+   * Determines if the block can be displayed for the given contact type.
+   *
+   * If the block is for a contact's relation then we determine if the given
+   * contact type and the relation's contact type match.
+   *
+   * When the block has no relation we match the block's contact type to the
+   * given contact type.
+   *
+   * @param array $blockInfo
+   * @param string $blockRelation
+   * @param string $contactType
+   * @return bool
+   */
+  protected static function checkBlockValidity ($blockInfo, $blockRelation = NULL, $contactType = NULL) {
+    if ($blockRelation) {
+      $relationship = self::getRelationshipFromOption($blockRelation);
+
+      return
+        ($relationship['direction'] === 'r' && (
+          ($contactType === $relationship['type']['contact_type_a'] &&
+            $blockInfo['contact_type'] === $relationship['type']['contact_type_b']) ||
+          ($contactType === $relationship['type']['contact_type_b'] &&
+            $blockInfo['contact_type'] === $relationship['type']['contact_type_a']))) ||
+        ($relationship['direction'] === 'ab' && (
+          $blockInfo['contact_type'] === $relationship['type']['contact_type_a'] &&
+          $contactType === $relationship['type']['contact_type_b'])) ||
+        ($relationship['direction'] === 'ba' && (
+          $blockInfo['contact_type'] === $relationship['type']['contact_type_b'] &&
+          $contactType === $relationship['type']['contact_type_a']));
+    } else {
+      return $blockInfo && (!$contactType || empty($blockInfo['contact_type']) || $contactType == $blockInfo['contact_type']);
+    }
+  }
+
+  /**
+   * Returns the relationship type and direction for the given parameter.
+   *
+   * The parameter might come in the format `15_ab` where `15` is the relationship
+   * type ID, and `ab` is the direction.
+   *
+   * @param string $relationshipOption
+   * @return array
+   */
+  protected static function getRelationshipFromOption ($relationshipOption) {
+    $relationship = explode('_', $relationshipOption);
+    $relationshipTypeId = $relationship[0];
+    $relationshipType = \Civi\Api4\RelationshipType::get()
+      ->addWhere('id', '=', $relationshipTypeId)
+      ->addWhere('is_active', '=', TRUE)
+      ->execute()
+      ->first();
+
+    return [
+      'type' => $relationshipType,
+      'direction' => $relationship[1]
+    ];
   }
 
   /**

--- a/CRM/Contactlayout/BAO/ContactLayout.php
+++ b/CRM/Contactlayout/BAO/ContactLayout.php
@@ -144,12 +144,12 @@ class CRM_Contactlayout_BAO_ContactLayout extends CRM_Contactlayout_DAO_ContactL
     if ($blockRelation) {
       try {
         $relationship = self::getRelationshipFromOption($blockRelation);
-      } catch (Exception $exception) {
+      }
+      catch (Exception $exception) {
         return FALSE;
       }
 
-      return
-        ($relationship['direction'] === 'r' && (
+      return ($relationship['direction'] === 'r' && (
           ($contactType === $relationship['type']['contact_type_a'] &&
             $blockInfo['contact_type'] === $relationship['type']['contact_type_b']) ||
           ($contactType === $relationship['type']['contact_type_b'] &&
@@ -160,7 +160,8 @@ class CRM_Contactlayout_BAO_ContactLayout extends CRM_Contactlayout_DAO_ContactL
         ($relationship['direction'] === 'ba' && (
           $blockInfo['contact_type'] === $relationship['type']['contact_type_b'] &&
           $contactType === $relationship['type']['contact_type_a']));
-    } else {
+    }
+    else {
       return $blockInfo && (!$contactType || empty($blockInfo['contact_type']) || $contactType == $blockInfo['contact_type']);
     }
   }
@@ -189,7 +190,7 @@ class CRM_Contactlayout_BAO_ContactLayout extends CRM_Contactlayout_DAO_ContactL
 
     return [
       'type' => $relationshipType,
-      'direction' => $relationship[1]
+      'direction' => $relationship[1],
     ];
   }
 

--- a/ang/contactlayout.ang.php
+++ b/ang/contactlayout.ang.php
@@ -1,7 +1,11 @@
 <?php
 // Declare contactlayout angular module
 
-// Returns a list of active relationship types
+/**
+ * Returns a list of active relationship types.
+ *
+ * @return array
+ */
 function getActiveRelationshipTypes() {
   return (array) Civi\Api4\RelationshipType::get()
     ->addWhere('is_active', '=', TRUE)

--- a/ang/contactlayout.ang.php
+++ b/ang/contactlayout.ang.php
@@ -1,6 +1,13 @@
 <?php
 // Declare contactlayout angular module
 
+// Returns a list of active relationship types
+function getActiveRelationshipTypes() {
+  return (array) Civi\Api4\RelationshipType::get()
+    ->addWhere('is_active', '=', TRUE)
+    ->execute();
+}
+
 return [
   'js' => [
     'ang/contactlayout/*.js',
@@ -11,6 +18,9 @@ return [
   ],
   'partials' => [
     'ang/contactlayout',
+  ],
+  'settings' => [
+    'relationshipTypes' => getActiveRelationshipTypes(),
   ],
   'requires' => ['crmUi', 'crmUtil', 'ngRoute', 'ui.sortable', 'api4'],
 ];

--- a/ang/contactlayout.css
+++ b/ang/contactlayout.css
@@ -380,6 +380,10 @@
   font-size: 13px;
 }
 
+.crm-container .contactlayout__relatioonship-dialog .select2-container {
+  min-width: calc(100% - 30px);
+}
+
 .contactlayout__relatioonship-dialog__illustration {
   align-items: center;
   color: gray;

--- a/ang/contactlayout/contactlayout.html
+++ b/ang/contactlayout/contactlayout.html
@@ -117,7 +117,7 @@
                     </div>
                   </h4>
                   <div id="cse-palette" class="cse-col cse-drop" ui-sortable="{connectWith: '.cse-drop', containment: '#cse-block-container', update: enforceUnique, cancel: 'input,textarea,button,select,option,a,.invalid-block'}" ng-model="selectedLayout.palette">
-                    <div class="cse-block" ng-repeat="block in selectedLayout.palette" ng-class="{'invalid-block': selectedLayout.contact_type && block.contact_type && selectedLayout.contact_type !== block.contact_type}" ng-include="'~/contactlayout/contactlayoutblock.html'"></div>
+                    <div class="cse-block" ng-repeat="block in selectedLayout.palette" ng-class="{'invalid-block': !checkBlockValidity(block)}" ng-include="'~/contactlayout/contactlayoutblock.html'"></div>
                   </div>
                 </div>
               </div>

--- a/ang/contactlayout/contactlayout.js
+++ b/ang/contactlayout/contactlayout.js
@@ -183,6 +183,10 @@
         },
         // Stores the relationship label and contact icons for the selected relationship option
         storeRelationshipInfoForSelectedOption: function () {
+          if (!model.selectedRelationship) {
+            return;
+          }
+
           var relationship = contactLayoutRelationshipOptions.getRelationshipFromOption(model.selectedRelationship);
           var relationshipOption = _.find(model.relationshipOptions.options, { id: model.selectedRelationship });
           var contactIcons = relationship.direction === 'r'

--- a/ang/contactlayout/contactlayout.js
+++ b/ang/contactlayout/contactlayout.js
@@ -65,12 +65,12 @@
             (relationship.type.contact_type_b === block.contact_type &&
               relationship.type.contact_type_a === $scope.selectedLayout.contact_type);
         } else {
-          var contactTypes = relationship.direction === 'ab'
-            ? { onBlock: relationship.type.contact_type_a, viewing: relationship.type.contact_type_b }
-            : { onBlock: relationship.type.contact_type_b, viewing: relationship.type.contact_type_a };
+          var contactTypes = relationship.direction === 'ab' ?
+            { onBlock: relationship.type.contact_type_a, viewing: relationship.type.contact_type_b } :
+            { onBlock: relationship.type.contact_type_b, viewing: relationship.type.contact_type_a };
 
-          return $scope.selectedLayout.contact_type === contactTypes.viewing
-            || block.contact_type === contactTypes.onBlock;
+          return $scope.selectedLayout.contact_type === contactTypes.viewing ||
+            block.contact_type === contactTypes.onBlock;
         }
       }
     };
@@ -189,13 +189,7 @@
 
           var relationship = contactLayoutRelationshipOptions.getRelationshipFromOption(model.selectedRelationship);
           var relationshipOption = _.find(model.relationshipOptions.options, { id: model.selectedRelationship });
-          var contactIcons = relationship.direction === 'r'
-            ? block.contact_type === relationship.type.contact_type_a
-              ? { onBlock: relationship.type.contact_type_a, viewing: relationship.type.contact_type_b }
-              : { onBlock: relationship.type.contact_type_b, viewing: relationship.type.contact_type_a }
-            : relationship.direction === 'ab'
-              ? { onBlock: relationship.type.contact_type_a, viewing: relationship.type.contact_type_b }
-              : { onBlock: relationship.type.contact_type_b, viewing: relationship.type.contact_type_a };
+          var contactIcons = getIconsForRelationship(relationship, block);
 
           model.relationshipLabel = relationshipOption.text;
           model.contactIcons.onBlock = CONTACT_ICONS[contactIcons.onBlock] || CONTACT_ICONS.Individual;
@@ -210,7 +204,7 @@
             text: ts('Save'),
             icons: { primary: 'fa-check' },
             click: function () {
-              block.related_rel = model.selectedRelationship,
+              block.related_rel = model.selectedRelationship;
 
               dialogService.close('editBlockRelationshipDialog');
               $scope.$digest();
@@ -263,6 +257,19 @@
         });
       });
       return blocksInLayout;
+    }
+
+    // Returns the set of icons for the given relationship type, direction, and block's contact type.
+    function getIconsForRelationship(relationship, block) {
+      if (relationship.direction === 'r') {
+        return block.contact_type === relationship.type.contact_type_a ?
+          { onBlock: relationship.type.contact_type_a, viewing: relationship.type.contact_type_b } :
+          { onBlock: relationship.type.contact_type_b, viewing: relationship.type.contact_type_a };
+      } else {
+        return relationship.direction === 'ab' ?
+          { onBlock: relationship.type.contact_type_a, viewing: relationship.type.contact_type_b } :
+          { onBlock: relationship.type.contact_type_b, viewing: relationship.type.contact_type_a };
+      }
     }
 
     $scope.deleteBlock = function(block) {

--- a/ang/contactlayout/contactlayout.js
+++ b/ang/contactlayout/contactlayout.js
@@ -1,4 +1,4 @@
-(function(angular, $, _, RELATIONSHIP_TYPES) {
+(function(angular, $, _) {
   // Autoload dependencies.
   angular.module('contactlayout', CRM.angRequires('contactlayout'));
 
@@ -614,8 +614,9 @@
   // Service for loading relationship type options and displaying loading state.
   angular.module('contactlayout')
     .service('contactLayoutRelationshipOptions', function (crmApi4) {
-      var relationshipOptionsPromise;
+      var RELATIONSHIP_TYPES = CRM.contactlayout.relationshipTypes;
       var service = this;
+
 
       service.options = formatRelationshipOptions(RELATIONSHIP_TYPES);
       service.getRelationshipFromOption = getRelationshipFromOption;
@@ -653,4 +654,4 @@
       }
     });
 
-})(angular, CRM.$, CRM._, CRM['contactlayout'].relationshipTypes);
+})(angular, CRM.$, CRM._);

--- a/ang/contactlayout/contactlayout.js
+++ b/ang/contactlayout/contactlayout.js
@@ -1,4 +1,4 @@
-(function(angular, $, _) {
+(function(angular, $, _, RELATIONSHIP_TYPES) {
   // Autoload dependencies.
   angular.module('contactlayout', CRM.angRequires('contactlayout'));
 
@@ -176,7 +176,6 @@
         ]
       };
 
-      contactLayoutRelationshipOptions.loadOptions();
       dialogService.open(
         'editBlockRelationshipDialog',
         '~/contactlayout/edit-block-relationship-dialog.html',
@@ -567,26 +566,7 @@
       var relationshipOptionsPromise;
       var service = this;
 
-      service.isLoading = false;
-      service.options = [];
-
-      // loads and stores the relationship type options.
-      service.loadOptions = function () {
-        service.isLoading = true;
-
-        if (!relationshipOptionsPromise) {
-          relationshipOptionsPromise = crmApi4('RelationshipType', 'get', {
-            where: [['is_active', '=', true]]
-          });
-        }
-
-        return relationshipOptionsPromise
-          .then(formatRelationshipOptions)
-          .then(function (options) {
-            service.isLoading = false;
-            service.options = options;
-          })
-      };
+      service.options = formatRelationshipOptions(RELATIONSHIP_TYPES);
 
       // for each relationship type, it includes an option for the a_b relationship
       // and another for the b_a relationship.
@@ -609,4 +589,4 @@
       }
     });
 
-})(angular, CRM.$, CRM._);
+})(angular, CRM.$, CRM._, CRM['contactlayout'].relationshipTypes);

--- a/ang/contactlayout/edit-block-relationship-dialog.html
+++ b/ang/contactlayout/edit-block-relationship-dialog.html
@@ -5,7 +5,7 @@
     <div class="label">
       Relationship
     </div>
-    <div class="content" ng-if="model.relationshipOptions.isLoading === false">
+    <div class="content">
       <input
         ng-model="model.selectedRelationship"
         crm-ui-select="{
@@ -18,7 +18,7 @@
       <a class="helpicon" title="Field Help" aria-label="Field Help" href="#" ng-click="model.displayHelp($event)">&nbsp;</a>
     </div>
     <div
-      ng-if="model.selectedRelationship && !model.relationshipOptions.isLoading"
+      ng-if="model.selectedRelationship"
       class="contactlayout__relatioonship-dialog__illustration">
       <div class="contactlayout__relatioonship-dialog__illustration__contact">
         <i class="fa fa-user"></i><br />
@@ -33,11 +33,6 @@
         <i class="fa fa-user"></i><br />
         <small>Contact we are viewing</small>
       </div>
-    </div>
-    <div class="content" ng-if="model.relationshipOptions.isLoading">
-      <i
-        ng-if="model.relationshipOptions.isLoading"
-        class="fa fa-spinner fa-pulse fa-fw"></i>
     </div>
   </div>
 </div>

--- a/ang/contactlayout/edit-block-relationship-dialog.html
+++ b/ang/contactlayout/edit-block-relationship-dialog.html
@@ -8,6 +8,7 @@
     <div class="content">
       <input
         ng-model="model.selectedRelationship"
+        ng-change="model.storeRelationshipInfoForSelectedOption()"
         crm-ui-select="{
           data: model.relationshipOptions.options,
           dropdownAutoWidth : true,
@@ -21,16 +22,16 @@
       ng-if="model.selectedRelationship"
       class="contactlayout__relatioonship-dialog__illustration">
       <div class="contactlayout__relatioonship-dialog__illustration__contact">
-        <i class="fa fa-user"></i><br />
+        <i class="{{model.contactIcons.onBlock}}"></i><br />
         <small>Contact on block</small>
       </div>
       <div class="contactlayout__relatioonship-dialog__illustration__relationship-type">
         <i class="fa fa-long-arrow-right"></i>
-        <small>{{model.getSelectedRelationshipLabel()}}</small>
+        <small>{{model.relationshipLabel}}</small>
         <i class="fa fa-long-arrow-right"></i>
       </div>
       <div class="contactlayout__relatioonship-dialog__illustration__contact">
-        <i class="fa fa-user"></i><br />
+        <i class="{{model.contactIcons.viewing}}"></i><br />
         <small>Contact we are viewing</small>
       </div>
     </div>


### PR DESCRIPTION
## Overview

This PR Adds support for displaying blocks in layouts that are meant for different contact types.

This closes https://github.com/civicrm/org.civicrm.contactlayout/issues/71

## How it looks
### Selecting a relationship
![gif](https://user-images.githubusercontent.com/1642119/87467860-9cadb080-c5e6-11ea-9289-4f9e30e2c07c.gif)
### Contact record
![Adam_Apple_c8008](https://user-images.githubusercontent.com/1642119/87468934-75f07980-c5e8-11ea-8a57-a911a84f62b9.png)

## Technical details

* We now provide the list of relationship types as an angular setting instead of fetching them on demand. The reason for this is that we need to have the relationship types to check if the blocks can be dragged onto the given layout. This simplifies accessing the relationship types.
*  On the front-end, the `checkBlockValidity` function determines if the block can be dragged for the given layout. This is how it works for the given scenarios:
  * When the layout does not specify a contact type it will always set the block as valid.
  * When the layout specifies a contact type, but the block has no relationship selected, it will mark the block as valid only when the block's contact type is the same as the layout's.
  * When the layout specifies a contact type and the block has a relationship selected, it will mark the block as valid as long as the relationship between the block and the layout's contact type is valid.
* Icons change depending on the contact types for the selected relationship. This is taken care of by the `storeRelationshipInfoForSelectedOption` function.
* On the backend, the `checkBlockValidity` function does a similar check as the one in the front end. This will include the given block even if its contact type is different from the page's contact type.
* The CSS change expands the relationship select to the full width of the modal window.