### PR TITLE
Cast api4 results to array before serializing

### DIFF
--- a/CRM/Contactlayout/Page/Angular.php
+++ b/CRM/Contactlayout/Page/Angular.php
@@ -5,18 +5,18 @@ class CRM_Contactlayout_Page_Angular extends CRM_Core_Page {
 
   public function run() {
     Civi::resources()->addVars(E::SHORT_NAME, [
-      'layouts' => civicrm_api4('ContactLayout', 'get', ['orderBy' => ['weight' => 'ASC']]),
-      'blocks' => civicrm_api4('ContactLayout', 'getBlocks'),
-      'tabs' => civicrm_api4('ContactLayout', 'getTabs'),
-      'contactTypes' => civicrm_api4('ContactType', 'get', [
+      'layouts' => (array) civicrm_api4('ContactLayout', 'get', ['orderBy' => ['weight' => 'ASC']]),
+      'blocks' => (array) civicrm_api4('ContactLayout', 'getBlocks'),
+      'tabs' => (array) civicrm_api4('ContactLayout', 'getTabs'),
+      'contactTypes' => (array) civicrm_api4('ContactType', 'get', [
         'where' => [['is_active', '=', 1]],
         'orderBy' => ['label' => 'ASC']
       ]),
-      'groups' => civicrm_api4('Group', 'get', [
+      'groups' => (array) civicrm_api4('Group', 'get', [
         'select' => ['name','title','description'],
         'where' => [['is_hidden', '=', 0], ['is_active', '=', 1], ['saved_search_id','IS NULL']]
       ]),
-      'relationshipTypes' => civicrm_api4('RelationshipType', 'get', ['where' => [['is_active', '=', TRUE]]]),
+      'relationshipTypes' => (array) civicrm_api4('RelationshipType', 'get', ['where' => [['is_active', '=', TRUE]]]),
     ]);
 
     // Load angular module


### PR DESCRIPTION
Fixes #78 

This isn't needed in Civi 5.25+; adding to support older versions of civi.