### PR TITLE
Add bootstrap3 bundle (requires 5.31)

### DIFF
--- a/CRM/Contactlayout/Page/Angular.php
+++ b/CRM/Contactlayout/Page/Angular.php
@@ -17,7 +17,8 @@ class CRM_Contactlayout_Page_Angular extends CRM_Core_Page {
         'where' => [['is_hidden', '=', 0], ['is_active', '=', 1], ['saved_search_id', 'IS NULL']],
       ]),
       'relationshipTypes' => (array) civicrm_api4('RelationshipType', 'get', ['where' => [['is_active', '=', TRUE]]]),
-    ]);
+    ])
+      ->addBundle('bootstrap3');
 
     // Load angular module
     $loader = new Civi\Angular\AngularLoader();

--- a/info.xml
+++ b/info.xml
@@ -18,7 +18,7 @@
   <version>1.7.2</version>
   <develStage>stable</develStage>
   <compatibility>
-    <ver>5.19</ver>
+    <ver>5.31</ver>
   </compatibility>
   <comments>Looks best with a bootstrap theme such as Shoreditch.</comments>
   <requires>


### PR DESCRIPTION
This makes use of the new `addBundle()` method in Civi 5.31. This breaks backward compatibility with earlier versions of Civi.