### PR TITLE
Do not display a relationship to a deleted contact

### DIFF
--- a/CRM/Contactlayout/Helper/ProfileRelatedContact.php
+++ b/CRM/Contactlayout/Helper/ProfileRelatedContact.php
@@ -54,6 +54,7 @@ class CRM_Contactlayout_Helper_ProfileRelatedContact {
       {$contactCondition}
       AND (r.start_date IS NULL OR r.start_date <= %3)
       AND (r.end_date IS NULL OR r.end_date >= %3)
+      AND c.is_deleted = 0
       LIMIT 1;
     ";
 


### PR DESCRIPTION
To reproduce:

* Display a block for a relationship type
* Create two contacts, then create the relationship between them.
* Notice how the layout displays the relationship between the contacts

Then:

* Problem 1: Delete the other contact - the contact will still be displayed in the block.
* Problem 2: Add a new relationship to another contact - it will still display the deleted contact