### PR TITLE
Disable permission check to retrieve default tabs

### DIFF
--- a/contactlayout.php
+++ b/contactlayout.php
@@ -131,7 +131,7 @@ function contactlayout_civicrm_pageRun(&$page) {
   if (get_class($page) === 'CRM_Contact_Page_View_Summary') {
     $contactID = $page->getVar('_contactId');
     if ($contactID) {
-      $defaultTabs = \Civi\Api4\Setting::get()
+      $defaultTabs = \Civi\Api4\Setting::get(FALSE)
         ->addSelect('contactlayout_default_tabs')
         ->execute()
         ->first()['value'] ?? NULL;


### PR DESCRIPTION
Attempt to fix #98 

Since restricted users do not have access to `\Civi\Api4\Setting::get`, we have to skip permission checks.
As this request only retrieves the default tabs that should be fine.