### PR TITLE
Groups filter - support smart groups and nested groups

### DIFF
--- a/info.xml
+++ b/info.xml
@@ -18,7 +18,7 @@
   <version>2.0.2</version>
   <develStage>stable</develStage>
   <compatibility>
-    <ver>5.38</ver>
+    <ver>5.39</ver>
   </compatibility>
   <civix>
     <namespace>CRM/Contactlayout</namespace>


### PR DESCRIPTION
The new 'groups' api filter works with smart groups as well as group nesting.
Fixes #92
Fixes #64

Note, this depends on #20507 which will be in the CiviCRM 5.39 release.