### PR TITLE
Fixes #107 - groups pseudoconstant lookup broken in APIv4

### DIFF
--- a/CRM/Contactlayout/BAO/ContactLayout.php
+++ b/CRM/Contactlayout/BAO/ContactLayout.php
@@ -57,10 +57,14 @@ class CRM_Contactlayout_BAO_ContactLayout extends CRM_Contactlayout_DAO_ContactL
     if (!$groups) {
       return TRUE;
     }
+    $groupIds = array_map(function($groupName) {
+      return CRM_Core_DAO::getFieldValue('CRM_Contact_DAO_Group', $groupName, 'id', 'name');
+    }, $groups);
     return (bool) \Civi\Api4\Contact::get(FALSE)
       ->addSelect('id')
       ->addWhere('id', '=', $uid)
-      ->addWhere('groups:name', 'IN', $groups)
+      // TODO: Change this back to ('groups:name', 'IN', $groups) when fixed upstream
+      ->addWhere('groups', 'IN', $groupIds)
       ->execute()->count();
   }
 


### PR DESCRIPTION
Fixes #107

Pseudoconstant lookups in calculated fields are currently broken upstream in APIv4 so this works around it for now.