### PR TITLE
Add CSS class for Edit Layout, for easier theming

### DIFF
--- a/contactlayout.php
+++ b/contactlayout.php
@@ -200,7 +200,7 @@ function contactlayout_civicrm_pageRun(&$page) {
       if (CRM_Core_Permission::check('administer CiviCRM')) {
         CRM_Core_Region::instance('contact-actions-ribbon')
           ->add([
-            'markup' => '<li style="float:right;">
+            'markup' => '<li class="crm-contact-summary-edit-layout">
               <a class="crm-hover-button" title="' . htmlspecialchars(E::ts('Edit Layout')) . '" href="' . CRM_Utils_System::url('civicrm/admin/contactlayout') . '">
                 <i class="crm-i fa-edit"></i> ' . htmlspecialchars(E::ts('Layout: %1', [1 => $layout['label'] ?? E::ts('System Default')])) .
             '</a>

--- a/css/contact-summary-layout.css
+++ b/css/contact-summary-layout.css
@@ -11,3 +11,6 @@
 #crm-contact-thumbnail + .crm-inline-block-content {
   clear: left;
 }
+#crm-container .crm-actions-ribbon .crm-contact-summary-edit-layout {
+  float: right;
+}


### PR DESCRIPTION
Adds a class to the "Layout: xx" link so that it can be more easily overridden with custom theming.

(The link is a good idea, but I ran into situations where users are admins but found it too distracting)

The specific CSS selector was to make sure it took precedence over Shoreditch CSS.