### PR TITLE
Support multiple contact types for each block or tab

### DIFF
--- a/CRM/Contactlayout/BAO/ContactLayout.php
+++ b/CRM/Contactlayout/BAO/ContactLayout.php
@@ -175,21 +175,28 @@ class CRM_Contactlayout_BAO_ContactLayout extends CRM_Contactlayout_DAO_ContactL
         return FALSE;
       }
 
-      return ($relationship['direction'] === 'r' && (
-          ($contactType === $relationship['type']['contact_type_a'] &&
-            $blockContactType === $relationship['type']['contact_type_b']) ||
-          ($contactType === $relationship['type']['contact_type_b'] &&
-            $blockContactType === $relationship['type']['contact_type_a']))) ||
-        ($relationship['direction'] === 'ab' && (
-          $blockContactType === $relationship['type']['contact_type_a'] &&
-          $contactType === $relationship['type']['contact_type_b'])) ||
-        ($relationship['direction'] === 'ba' && (
-          $blockContactType === $relationship['type']['contact_type_b'] &&
-          $contactType === $relationship['type']['contact_type_a']));
+      return self::checkBlockRelation($relationship, $contactType, $blockContactType);
     }
     else {
-      return $blockInfo && (!$contactType || !$blockContactType || $contactType == $blockContactType);
+      return $blockInfo && (!$contactType || !$blockContactType || in_array($contactType, (array) $blockContactType, TRUE));
     }
+  }
+
+  /**
+   * @param array $relationship
+   * @param $contactType
+   * @param $blockContactType
+   * @return bool
+   */
+  private static function checkBlockRelation(array $relationship, $contactType, $blockContactType) {
+    // Reciprocal relationship - check both directions
+    if ($relationship['direction'] === 'r') {
+      return self::checkBlockRelation(['direction' => 'ab'] + $relationship, $contactType, $blockContactType) ||
+        self::checkBlockRelation(['direction' => 'ba'] + $relationship, $contactType, $blockContactType);
+    }
+    [$a, $b] = str_split($relationship['direction']);
+    return $contactType === $relationship['type']["contact_type_$b"] &&
+      ((!$blockContactType && !$relationship['type']["contact_type_$a"]) || in_array($relationship['type']["contact_type_$a"], $blockContactType, TRUE));
   }
 
   /**
@@ -198,10 +205,11 @@ class CRM_Contactlayout_BAO_ContactLayout extends CRM_Contactlayout_DAO_ContactL
    * The parameter might come in the format `15_ab` where `15` is the relationship
    * type ID, and `ab` is the direction.
    *
+   * @throws Exception
    * @param string $relationshipOption
    * @return array
    */
-  protected static function getRelationshipFromOption($relationshipOption) {
+  protected static function getRelationshipFromOption($relationshipOption): array {
     $relationship = explode('_', $relationshipOption);
     $relationshipTypeId = $relationship[0];
     $relationshipType = \Civi\Api4\RelationshipType::get(FALSE)
@@ -225,7 +233,8 @@ class CRM_Contactlayout_BAO_ContactLayout extends CRM_Contactlayout_DAO_ContactL
    * @return array
    */
   protected static function loadAllBlocks() {
-    $contactTypes = CRM_Contact_BAO_ContactType::basicTypes(TRUE);
+    $enabledContactTypes = CRM_Contact_BAO_ContactType::basicTypes();
+    $allContactTypes = CRM_Contact_BAO_ContactType::basicTypes(TRUE);
     $blocks = [
       'core' => [
         'title' => E::ts('Predefined'),
@@ -298,7 +307,7 @@ class CRM_Contactlayout_BAO_ContactLayout extends CRM_Contactlayout_DAO_ContactL
       'sample' => [E::ts('User')],
       'edit' => FALSE,
       'selector' => '#crm-openid-content',
-      'contact_type' => 'Individual',
+      'contact_type' => ['Individual'],
       'system_default' => [1, 1],
     ];
     $blocks['core']['blocks']['Address'] = [
@@ -324,7 +333,7 @@ class CRM_Contactlayout_BAO_ContactLayout extends CRM_Contactlayout_DAO_ContactL
       'sample' => [E::ts('Gender'), E::ts('Date of Birth'), E::ts('Age')],
       'edit' => FALSE,
       'selector' => '#crm-demographic-content',
-      'contact_type' => 'Individual',
+      'contact_type' => ['Individual'],
       'system_default' => [3, 1],
     ];
 
@@ -340,7 +349,7 @@ class CRM_Contactlayout_BAO_ContactLayout extends CRM_Contactlayout_DAO_ContactL
       ->addGroupBy('id')
       ->execute();
     foreach ($profiles as $profile) {
-      $profileType = array_intersect($contactTypes, $profile['uf_group_id.group_type'] ?? []);
+      $profileType = array_intersect($allContactTypes, $profile['uf_group_id.group_type'] ?? []);
       $blocks['profile']['blocks'][$profile['uf_group_id.name']] = [
         'title' => $profile['uf_group_id.title'],
         'tpl_file' => 'CRM/Contactlayout/Page/Inline/Profile.tpl',
@@ -350,7 +359,7 @@ class CRM_Contactlayout_BAO_ContactLayout extends CRM_Contactlayout_DAO_ContactL
         'edit' => TRUE,
         'refresh' => [],
         'selector' => '#crm-profile-content-' . $profile['uf_group_id.name'],
-        'contact_type' => CRM_Utils_Array::first($profileType),
+        'contact_type' => $profileType ?: NULL,
       ];
     }
 
@@ -358,7 +367,7 @@ class CRM_Contactlayout_BAO_ContactLayout extends CRM_Contactlayout_DAO_ContactL
       ->addSelect('id', 'name', 'title', 'is_multiple', 'collapse_display', 'extends')
       ->addSelect('GROUP_CONCAT(fields.id) AS field_ids')
       ->addSelect('GROUP_CONCAT(fields.label ORDER BY fields.weight) AS field_labels')
-      ->addWhere('extends', 'IN', array_merge(['Contact'], $contactTypes))
+      ->addWhere('extends', 'IN', array_merge(['Contact'], $enabledContactTypes))
       ->addWhere('style', '=', 'Inline')
       ->addWhere('is_active', '=', TRUE)
       ->addJoin('CustomField AS fields', 'LEFT',
@@ -378,7 +387,7 @@ class CRM_Contactlayout_BAO_ContactLayout extends CRM_Contactlayout_DAO_ContactL
         'collapsed' => !empty($group['collapse_display']),
         'edit' => 'civicrm/admin/custom/group/field?reset=1&action=browse&gid=' . $group['id'],
         'selector' => '#custom-set-content-' . $group['id'],
-        'contact_type' => $group['extends'] === 'Contact' ? NULL : $group['extends'],
+        'contact_type' => $group['extends'] === 'Contact' ? NULL : [$group['extends']],
         'system_default' => [4, $index % 2],
       ];
     }
@@ -477,9 +486,9 @@ class CRM_Contactlayout_BAO_ContactLayout extends CRM_Contactlayout_DAO_ContactL
    * @return array
    */
   public static function getAllTabs() {
-    $contactTypes = CRM_Contact_BAO_ContactType::basicTypes(TRUE);
+    $enabledContactTypes = CRM_Contact_BAO_ContactType::basicTypes();
     $tabs = CRM_Contact_Page_View_Summary::basicTabs();
-    foreach (CRM_Core_Component::getEnabledComponents() as $name => $component) {
+    foreach (CRM_Core_Component::getEnabledComponents() as $component) {
       $tab = $component->registerTab();
       if ($tab) {
         $tabs[] = $tab + ['id' => $component->getKeyword(), 'icon' => $component->getIcon()];
@@ -489,7 +498,7 @@ class CRM_Contactlayout_BAO_ContactLayout extends CRM_Contactlayout_DAO_ContactL
     $customGroups = \Civi\Api4\CustomGroup::get()
       ->addWhere('style', 'IN', ['Tab', 'Tab with table'])
       ->addWhere('is_active', '=', 1)
-      ->addWhere('extends', 'IN', array_merge(['Contact'], $contactTypes))
+      ->addWhere('extends', 'IN', array_merge(['Contact'], $enabledContactTypes))
       ->addOrderBy('weight')
       ->execute();
     foreach ($customGroups as $group) {
@@ -498,31 +507,28 @@ class CRM_Contactlayout_BAO_ContactLayout extends CRM_Contactlayout_DAO_ContactL
         'title' => $group['title'],
         'weight' => $weight += 10,
         'icon' => 'crm-i ' . ($group['icon'] ?? 'fa-gear'),
-        'contact_type' => $group['extends'] == 'Contact' ? NULL : $group['extends'],
+        'contact_type' => $group['extends'] == 'Contact' ? NULL : [$group['extends']],
       ];
     }
+    // Call the hook for extensions to add tabs
     $context = [
-      'contact_id' => CRM_Core_Session::getLoggedInContactID(),
-      'contact_type' => 'Individual',
+      'contact_id' => 0,
+      'contact_type' => NULL,
       'caller' => 'ContactLayout',
     ];
     CRM_Utils_Hook::tabset('civicrm/contact/view', $tabs, $context);
-    foreach ($tabs as &$tab) {
-      // Hack for CiviDiscount
-      if ($tab['id'] === 'discounts') {
-        $tabs[] = array(
-          'id' => 'discounts_assigned',
-          'title' => ts('Codes Assigned', ['domain' => 'org.civicrm.module.cividiscount']),
-          'weight' => 115,
-          'icon' => $tab['icon'],
-          'contact_type' => 'Organization',
-          'is_active' => TRUE,
-        );
-      }
-      $tab['is_active'] = TRUE;
+    $allTabs = [];
+    foreach ($tabs as $index => $tab) {
+      // Every tab OUGHT to have an 'id' but the documentation about this has been unclear.
+      // Proactively convert array key to id if missing.
+      $id = $tab['id'] ?? $index;
+      $allTabs[] = $tab + [
+        'is_active' => TRUE,
+        'id' => $index,
+      ];
     }
-    usort($tabs, ['CRM_Utils_Sort', 'cmpFunc']);
-    return $tabs;
+    usort($allTabs, ['CRM_Utils_Sort', 'cmpFunc']);
+    return $allTabs;
   }
 
 }

--- a/Civi/Api4/Action/ContactLayout/GetTabs.php
+++ b/Civi/Api4/Action/ContactLayout/GetTabs.php
@@ -30,6 +30,10 @@ class GetTabs extends \Civi\Api4\Generic\BasicGetAction {
         'data_type' => 'String',
       ],
       [
+        'name' => 'contact_type',
+        'data_type' => 'Array',
+      ],
+      [
         'name' => 'is_active',
         'data_type' => 'Boolean',
       ],

--- a/ang/contactlayout/contactLayoutEditTabs.component.js
+++ b/ang/contactlayout/contactLayoutEditTabs.component.js
@@ -36,6 +36,10 @@
         }
       };
 
+      this.tabIsValid = function(tab) {
+        return !tab.contact_type || !ctrl.contactType || tab.contact_type.includes(ctrl.contactType);
+      };
+
       this.pickTabIcon = function(tab) {
         editingTabIcon = tab;
         $('#cse-icon-picker ~ .crm-icon-picker-button').click();

--- a/ang/contactlayout/contactLayoutEditTabs.html
+++ b/ang/contactlayout/contactLayoutEditTabs.html
@@ -9,7 +9,7 @@
   </div>
   <!--  Editable tabs -->
   <div ng-if="$ctrl.layout.tabs" ui-sortable="$ctrl.sortableOptions" ng-model="$ctrl.layout.tabs">
-    <div class="cse-tab crm-draggable" data-tab-id="{{ tab.id }}" ng-if="!tab.contact_type || !$ctrl.contactType || tab.contact_type === $ctrl.contactType" ng-class="{'cse-tab-disabled': !tab.is_active}" ng-repeat="tab in $ctrl.layout.tabs">
+    <div class="cse-tab crm-draggable" data-tab-id="{{ tab.id }}" ng-if="$ctrl.tabIsValid(tab)" ng-class="{'cse-tab-disabled': !tab.is_active}" ng-repeat="tab in $ctrl.layout.tabs">
       <span class="cse-tab-icon crm-editable-enabled" ng-if="tab.is_active" ng-click="$ctrl.pickTabIcon(tab)">
         <i class="{{ tab.icon || 'crm-i fa-puzzle-piece' }}"></i>
       </span>
@@ -22,7 +22,7 @@
   </div>
   <!-- Default tabs -->
   <div ng-if="!$ctrl.layout.tabs">
-    <div class="cse-tab" ng-repeat="tab in $ctrl.defaults">
+    <div class="cse-tab" ng-repeat="tab in $ctrl.defaults" ng-if="$ctrl.tabIsValid(tab)">
       <span class="cse-tab-icon">
         <i class="{{ tab.icon || 'crm-i fa-puzzle-piece' }}"></i>
       </span>

--- a/ang/contactlayout/contactLayoutEditor.component.js
+++ b/ang/contactlayout/contactLayoutEditor.component.js
@@ -34,14 +34,14 @@
         if (!$scope.selectedLayout.contact_type) {
           return true;
         } else if (!block.related_rel) {
-          return !block.contact_type || ($scope.selectedLayout.contact_type === block.contact_type);
+          return !block.contact_type || (block.contact_type.includes($scope.selectedLayout.contact_type));
         } else {
           var relationship = contactLayoutRelationshipOptions.getRelationshipFromOption(block.related_rel);
 
           if (relationship.direction === 'r') {
-            return (relationship.type.contact_type_a === block.contact_type &&
+            return (block.contact_type.includes(relationship.type.contact_type_a) &&
               relationship.type.contact_type_b === $scope.selectedLayout.contact_type) ||
-              (relationship.type.contact_type_b === block.contact_type &&
+              (block.contact_type.includes(relationship.type.contact_type_b) &&
                 relationship.type.contact_type_a === $scope.selectedLayout.contact_type);
           } else {
             var contactTypes = relationship.direction === 'ab' ?
@@ -49,7 +49,7 @@
               {onBlock: relationship.type.contact_type_b, viewing: relationship.type.contact_type_a};
 
             return $scope.selectedLayout.contact_type === contactTypes.viewing ||
-              block.contact_type === contactTypes.onBlock;
+              block.contact_type.includes(contactTypes.onBlock);
           }
         }
       };
@@ -90,7 +90,7 @@
           _.each(layout.blocks, function(row) {
             _.each(row, function(col, i) {
               row[i] = _.filter(col, function(block) {
-                return !block.contact_type || block.contact_type === layout.contact_type;
+                return !block.contact_type || block.contact_type.includes(layout.contact_type);
               });
             });
           });
@@ -247,7 +247,7 @@
       // Returns the set of icons for the given relationship type, direction, and block's contact type.
       function getIconsForRelationship(relationship, block) {
         if (relationship.direction === 'r') {
-          return block.contact_type === relationship.type.contact_type_a ?
+          return block.contact_type.includes(relationship.type.contact_type_a) ?
             {onBlock: relationship.type.contact_type_a, viewing: relationship.type.contact_type_b} :
             {onBlock: relationship.type.contact_type_b, viewing: relationship.type.contact_type_a};
         } else {

--- a/info.xml
+++ b/info.xml
@@ -18,7 +18,7 @@
   <version>2.1.3</version>
   <develStage>stable</develStage>
   <compatibility>
-    <ver>5.45</ver>
+    <ver>5.57</ver>
   </compatibility>
   <civix>
     <namespace>CRM/Contactlayout</namespace>


### PR DESCRIPTION
As of 5.57, core and Afform both now provide contact type information in block and tab hooks.

See https://github.com/civicrm/civicrm-core/pull/25101