### PR TITLE
Fix fatal error for php8 when no custom fields in custom group

### DIFF
--- a/CRM/Contactlayout/BAO/ContactLayout.php
+++ b/CRM/Contactlayout/BAO/ContactLayout.php
@@ -403,7 +403,9 @@ class CRM_Contactlayout_BAO_ContactLayout extends CRM_Contactlayout_DAO_ContactL
   public static function addBlockRelations(&$blocks, $profiles, $customGroups) {
     $customFields = [];
     foreach ($customGroups as $group) {
-      $customFields['#custom-set-content-' . $group['id']] = $group['field_ids'];
+      if (!empty($group['field_ids'])) {
+        $customFields['#custom-set-content-' . $group['id']] = $group['field_ids'];
+      }
     }
     $coreBlocks = [
       '#crm-contactname-content' => [


### PR DESCRIPTION
When a custom group has no custom fields the screen throws a fatal error on php8.1 

````
TypeError: in_array(): Argument #2 ($haystack) must be of type array, null given in /home/drupal9/web/sites/default/files/civicrm/ext/org.civicrm.contactlayout/CRM/Contactlayout/BAO/ContactLayout.php on line 457 #0 /home/drupal9/web/sites/default/files/civicrm/ext/org.civicrm.contactlayout/CRM/Contactlayout/BAO/ContactLayout.php(457): in_array('133', NULL)
#1 /home/drupal9/web/sites/default/files/civicrm/ext/org.civicrm.contactlayout/CRM/Contactlayout/BAO/ContactLayout.php(386): CRM_Contactlayout_BAO_ContactLayout::addBlockRelations(Array, Object(Civi\Api4\Generic\Result), Object(Civi\Api4\Generic\Result))
#2 /home/drupal9/web/sites/default/files/civicrm/ext/org.civicrm.contactlayout/CRM/Contactlayout/BAO/ContactLayout.php(124): CRM_Contactlayout_BAO_ContactLayout::loadAllBlocks()
#3 /home/drupal9/web/sites/default/files/civicrm/ext/org.civicrm.contactlayout/CRM/Contactlayout/BAO/ContactLayout.php(145): CRM_Contactlayout_BAO_ContactLayout::getAllBlocks()
#4 /home/drupal9/web/sites/default/files/civicrm/ext/org.civicrm.contactlayout/CRM/Contactlayout/BAO/ContactLayout.php(96): CRM_Contactlayout_BAO_ContactLayout::getBlock('custom.Contact_...')
#5 /home/drupal9/web/sites/default/files/civicrm/ext/org.civicrm.contactlayout/CRM/Contactlayout/BAO/ContactLayout.php(40): CRM_Contactlayout_BAO_ContactLayout::loadBlocks(Array, 'Organization')
#6 /home/drupal9/web/sites/default/files/civicrm/ext/org.civicrm.contactlayout/contactlayout.php(100): CRM_Contactlayout_BAO_ContactLayout::getLayout(2906)
#7 /home/drupal9/vendor/civicrm/civicrm-core/CRM/Utils/Hook.php(271): contactlayout_civicrm_pageRun(Object(CRM_Contact_Page_View_Summary))
#8 /home/drupal9/vendor/civicrm/civicrm-core/CRM/Utils/Hook/DrupalBase.php(73): CRM_Utils_Hook->runHooks(Array, 'civicrm_pageRun', 1, Object(CRM_Contact_Page_View_Summary), NULL, NULL, NULL, NULL, NULL)
#9 /home/drupal9/vendor/civicrm/civicrm-core/Civi/Core/CiviEventDispatcher.php(306): CRM_Utils_Hook_DrupalBase->invokeViaUF(1, Object(CRM_Contact_Page_View_Summary), NULL, NULL, NULL, NULL, NULL, 'civicrm_pageRun')
#10 /home/drupal9/vendor/symfony/event-dispatcher/EventDispatcher.php(251): Civi\Core\CiviEventDispatcher::delegateToUF(Object(Civi\Core\Event\GenericHookEvent), 'hook_civicrm_pa...', Object(Civi\Core\UnoptimizedEventDispatcher))
#11 /home/drupal9/vendor/symfony/event-dispatcher/EventDispatcher.php(73): Symfony\Component\EventDispatcher\EventDispatcher->callListeners(Array, 'hook_civicrm_pa...', Object(Civi\Core\Event\GenericHookEvent))
#12 /home/drupal9/vendor/civicrm/civicrm-core/Civi/Core/CiviEventDispatcher.php(260): Symfony\Component\EventDispatcher\EventDispatcher->dispatch(Object(Civi\Core\Event\GenericHookEvent), 'hook_civicrm_pa...')
#13 /home/drupal9/vendor/civicrm/civicrm-core/CRM/Utils/Hook.php(167): Civi\Core\CiviEventDispatcher->dispatch('hook_civicrm_pa...', Object(Civi\Core\Event\GenericHookEvent))
#14 /home/drupal9/vendor/civicrm/civicrm-core/CRM/Utils/Hook.php(942): CRM_Utils_Hook->invoke(Array, Object(CRM_Contact_Page_View_Summary), NULL, NULL, NULL, NULL, NULL, 'civicrm_pageRun')
#15 /home/drupal9/vendor/civicrm/civicrm-core/CRM/Core/Page.php(212): CRM_Utils_Hook::pageRun(Object(CRM_Contact_Page_View_Summary))
#16 /home/drupal9/vendor/civicrm/civicrm-core/CRM/Contact/Page/View/Summary.php(86): CRM_Core_Page->run()
#17 /home/drupal9/vendor/civicrm/civicrm-core/CRM/Core/Invoke.php(319): CRM_Contact_Page_View_Summary->run(Array, NULL)
#18 /home/drupal9/vendor/civicrm/civicrm-core/CRM/Core/Invoke.php(69): CRM_Core_Invoke::runItem(Array)
#19 /home/drupal9/vendor/civicrm/civicrm-core/CRM/Core/Invoke.php(36): CRM_Core_Invoke::_invoke(Array)
#20 /home/drupal9/web/modules/contrib/civicrm/src/Civicrm.php(88): CRM_Core_Invoke::invoke(Array)
#21 /home/drupal9/web/modules/contrib/civicrm/src/Controller/CivicrmController.php(80): Drupal\civicrm\Civicrm->invoke(Array)
#22 [internal function]: Drupal\civicrm\Controller\CivicrmController->main(Array, '')
#23 /home/drupal9/web/core/lib/Drupal/Core/EventSubscriber/EarlyRenderingControllerWrapperSubscriber.php(123): call_user_func_array(Array, Array)
#24 /home/drupal9/web/core/lib/Drupal/Core/Render/Renderer.php(580): Drupal\Core\EventSubscriber\EarlyRenderingControllerWrapperSubscriber->Drupal\Core\EventSubscriber\{closure}()
#25 /home/drupal9/web/core/lib/Drupal/Core/EventSubscriber/EarlyRenderingControllerWrapperSubscriber.php(124): Drupal\Core\Render\Renderer->executeInRenderContext(Object(Drupal\Core\Render\RenderContext), Object(Closure))
#26 /home/drupal9/web/core/lib/Drupal/Core/EventSubscriber/EarlyRenderingControllerWrapperSubscriber.php(97): Drupal\Core\EventSubscriber\EarlyRenderingControllerWrapperSubscriber->wrapControllerExecutionInRenderContext(Array, Array)
#27 /home/drupal9/vendor/symfony/http-kernel/HttpKernel.php(169): Drupal\Core\EventSubscriber\EarlyRenderingControllerWrapperSubscriber->Drupal\Core\EventSubscriber\{closure}()
#28 /home/drupal9/vendor/symfony/http-kernel/HttpKernel.php(81): Symfony\Component\HttpKernel\HttpKernel->handleRaw(Object(Symfony\Component\HttpFoundation\Request), 1)
#29 /home/drupal9/web/core/lib/Drupal/Core/StackMiddleware/Session.php(58): Symfony\Component\HttpKernel\HttpKernel->handle(Object(Symfony\Component\HttpFoundation\Request), 1, true)
#30 /home/drupal9/web/core/lib/Drupal/Core/StackMiddleware/KernelPreHandle.php(48): Drupal\Core\StackMiddleware\Session->handle(Object(Symfony\Component\HttpFoundation\Request), 1, true)
#31 /home/drupal9/web/core/modules/page_cache/src/StackMiddleware/PageCache.php(106): Drupal\Core\StackMiddleware\KernelPreHandle->handle(Object(Symfony\Component\HttpFoundation\Request), 1, true)
#32 /home/drupal9/web/core/modules/page_cache/src/StackMiddleware/PageCache.php(85): Drupal\page_cache\StackMiddleware\PageCache->pass(Object(Symfony\Component\HttpFoundation\Request), 1, true)
#33 /home/drupal9/web/core/lib/Drupal/Core/StackMiddleware/ReverseProxyMiddleware.php(48): Drupal\page_cache\StackMiddleware\PageCache->handle(Object(Symfony\Component\HttpFoundation\Request), 1, true)
#34 /home/drupal9/web/core/lib/Drupal/Core/StackMiddleware/NegotiationMiddleware.php(51): Drupal\Core\StackMiddleware\ReverseProxyMiddleware->handle(Object(Symfony\Component\HttpFoundation\Request), 1, true)
#35 /home/drupal9/vendor/stack/builder/src/Stack/StackedHttpKernel.php(23): Drupal\Core\StackMiddleware\NegotiationMiddleware->handle(Object(Symfony\Component\HttpFoundation\Request), 1, true)
#36 /home/drupal9/web/core/lib/Drupal/Core/DrupalKernel.php(718): Stack\StackedHttpKernel->handle(Object(Symfony\Component\HttpFoundation\Request), 1, true)
#37 /home/drupal9/web/index.php(19): Drupal\Core\DrupalKernel->handle(Object(Symfony\Component\HttpFoundation\Request))
#38 {main}
````
