### PR TITLE
Improve handling newly-added tabs

### DIFF
--- a/CRM/Contactlayout/BAO/ContactLayout.php
+++ b/CRM/Contactlayout/BAO/ContactLayout.php
@@ -524,7 +524,6 @@ class CRM_Contactlayout_BAO_ContactLayout extends CRM_Contactlayout_DAO_ContactL
     foreach ($tabs as $index => $tab) {
       // Every tab OUGHT to have an 'id' but the documentation about this has been unclear.
       // Proactively convert array key to id if missing.
-      $id = $tab['id'] ?? $index;
       $allTabs[] = $tab + [
         'is_active' => TRUE,
         'id' => $index,

--- a/ang/contactlayout/contactLayoutEditTabs.component.js
+++ b/ang/contactlayout/contactLayoutEditTabs.component.js
@@ -2,7 +2,7 @@
 
   angular.module('contactlayout').component('contactLayoutEditTabs', {
     bindings:  {
-      defaults: '=',
+      defaults: '<',
       layout: '<',
       contactType: '<',
       isSystem: '<'
@@ -20,12 +20,25 @@
         cancel: 'input,textarea,button,select,option,a,.crm-editable-enabled,[contenteditable]'
       };
 
+      this.$onInit = () => {
+        // Check default & active tabsets for any missing tabs (e.g. from a newly-enabled extension)
+        this.defaultTabs = angular.copy(this.defaults);
+        CRM.vars.contactlayout.tabs.forEach((tab) => {
+          if (!_.findWhere(ctrl.defaultTabs, {id: tab.id})) {
+            ctrl.defaultTabs.push(angular.copy(tab));
+          }
+          if (ctrl.layout.tabs && !_.findWhere(ctrl.layout.tabs, {id: tab.id})) {
+            ctrl.layout.tabs.push(angular.copy(tab));
+          }
+        });
+      };
+
       // Toggle between using defaults & custom tabs
       this.toggleTabs = function() {
         if (ctrl.layout.tabs) {
           ctrl.layout.tabs = null;
         } else {
-          ctrl.layout.tabs = angular.copy(ctrl.defaults);
+          ctrl.layout.tabs = angular.copy(ctrl.defaultTabs);
         }
       };
 

--- a/ang/contactlayout/contactLayoutEditTabs.html
+++ b/ang/contactlayout/contactLayoutEditTabs.html
@@ -22,7 +22,7 @@
   </div>
   <!-- Default tabs -->
   <div ng-if="!$ctrl.layout.tabs">
-    <div class="cse-tab" ng-repeat="tab in $ctrl.defaults" ng-if="$ctrl.tabIsValid(tab)">
+    <div class="cse-tab" ng-repeat="tab in $ctrl.defaultTabs" ng-if="$ctrl.tabIsValid(tab)">
       <span class="cse-tab-icon">
         <i class="{{ tab.icon || 'crm-i fa-puzzle-piece' }}"></i>
       </span>


### PR DESCRIPTION
Before
----
When a new tab is added (e.g. from enabling a new extension) it shows up on the contact summary screen, but not in ContactLayoutEditor if the tabs have been modified.

After
------
Shows in both places.