### PR TITLE
blockContactType is always an array

### DIFF
--- a/CRM/Contactlayout/BAO/ContactLayout.php
+++ b/CRM/Contactlayout/BAO/ContactLayout.php
@@ -167,7 +167,7 @@ class CRM_Contactlayout_BAO_ContactLayout extends CRM_Contactlayout_DAO_ContactL
    * @return bool
    */
   protected static function checkBlockValidity($blockInfo, $blockRelation = NULL, $contactType = NULL) {
-    $blockContactType = $blockInfo['contact_type'] ?? NULL;
+    $blockContactType = $blockInfo['contact_type'] ?? [];
     if ($blockRelation) {
       try {
         $relationship = self::getRelationshipFromOption($blockRelation);
@@ -179,7 +179,7 @@ class CRM_Contactlayout_BAO_ContactLayout extends CRM_Contactlayout_DAO_ContactL
       return self::checkBlockRelation($relationship, $contactType, $blockContactType);
     }
     else {
-      return $blockInfo && (!$contactType || !$blockContactType || in_array($contactType, (array) $blockContactType, TRUE));
+      return $blockInfo && (!$contactType || !$blockContactType || in_array($contactType, $blockContactType, TRUE));
     }
   }
 
@@ -189,7 +189,7 @@ class CRM_Contactlayout_BAO_ContactLayout extends CRM_Contactlayout_DAO_ContactL
    * @param $blockContactType
    * @return bool
    */
-  private static function checkBlockRelation(array $relationship, $contactType, $blockContactType) {
+  private static function checkBlockRelation(array $relationship, $contactType, array $blockContactType) {
     // Reciprocal relationship - check both directions
     if ($relationship['direction'] === 'r') {
       return self::checkBlockRelation(['direction' => 'ab'] + $relationship, $contactType, $blockContactType) ||


### PR DESCRIPTION
https://github.com/civicrm/org.civicrm.contactlayout/pull/124 added support for multiple contact types for each block or tab.  But I was seeing this error:
```
PHP Fatal error:  Uncaught TypeError: in_array(): Argument #2 ($haystack) must be of type array, null given in /home/jon/local/mysite/web/wp-content/civicrm-custom/extensions/org.civicrm.contactlayout/CRM/Contactlayout/BAO/ContactLayout.php:200"
```

That's because we were setting `$blockContentType` to `NULL` instead of an empty array, but then using it in places that required an array.  I've fixed that and tightened up the type hint.