### PR TITLE
Fix fatal error on inline profile block

### DIFF
--- a/templates/CRM/Contactlayout/Form/Inline/ProfileBlock.tpl
+++ b/templates/CRM/Contactlayout/Form/Inline/ProfileBlock.tpl
@@ -27,12 +27,9 @@
             {strip}
               <table class="form-layout-compressed">
                 <tr>
-                  {* sort by fails for option per line. Added a variable to iterate through the element array*}
-                  {assign var="index" value="1"}
                   {foreach name=outer key=key item=item from=$form.$n}
-                  {if $index < 10}
-                  {assign var="index" value=$index+1}
-                  {else}
+                  {* There are both numeric and non-numeric keys mixed in here, where the non-numeric are metadata that aren't arrays with html members. *}
+                  {if is_array($item) && array_key_exists('html', $item)}
                   <td class="labels font-light">{$form.$n.$key.html}</td>
                   {if $count == $field.options_per_line}
                 </tr>


### PR DESCRIPTION
Fatal error on profile blocks on PHP 8.2


>TypeError: Cannot access offset of type string on string in include() (line 48 of web/sites/default/files/civicrm/templates_c/en_US/%%CC/CC2/CC20B997%%ProfileBlock.tpl.php).

This PR iterates the same fix done at https://github.com/civicrm/civicrm-core/pull/26517 & https://github.com/civicrm/civicrm-core/pull/26763

https://github.com/civicrm/org.civicrm.contactlayout/issues/142 seems like a related issue.