### PR TITLE
remove phone_ext as a distinct field

### DIFF
--- a/CRM/Contactlayout/Page/Inline/ProfileBlock.php
+++ b/CRM/Contactlayout/Page/Inline/ProfileBlock.php
@@ -83,6 +83,10 @@ class CRM_Contactlayout_Page_Inline_ProfileBlock extends CRM_Core_Page {
       if ($name == 'deceased_date' && empty($details['deceased_date'])) {
         continue;
       }
+      // Hide the pseudo field phone extension that is included in phone
+      if (str_starts_with($name, 'phone_ext')) {
+        continue;
+      }
       // Show Is Deceased message if no deceased date
       if ($name == 'is_deceased') {
         if ((!isset($fields['deceased_date']) || empty($details['deceased_date'])) && !empty($details['is_deceased'])) {


### PR DESCRIPTION
If you add a phone + extension in a profile and add it to you contact layout, it will display the phone with extension + the extension label as a distinct field as seen in the screenshot :+1: 

![Screenshot 2024-12-11 at 11-35-24](https://github.com/user-attachments/assets/abe41266-5f45-45e7-87bf-043e52fbffb1)

This PR removes the unecessary labels.