### PR TITLE
Smarty - Escape all translated html attributes

### DIFF
--- a/templates/CRM/Contactlayout/Page/Base.tpl
+++ b/templates/CRM/Contactlayout/Page/Base.tpl
@@ -3,7 +3,7 @@
   <contact-layout-editor></contact-layout-editor>
 
   <div style="display:none;">
-    <input id="cse-icon-picker" title="{ts}Choose Icon{/ts}"/>
+    <input id="cse-icon-picker" title="{ts escape='htmlattribute'}Choose Icon{/ts}"/>
   </div>
 </div>
 {* Since css files don't support translatable strings *}

--- a/templates/CRM/Contactlayout/Page/Inline/ProfileBlock.tpl
+++ b/templates/CRM/Contactlayout/Page/Inline/ProfileBlock.tpl
@@ -6,7 +6,7 @@
   {/if}
 >
   {if !$block.rel_is_missing}
-    <div class="crm-clear crm-inline-block-content" {if $permission EQ 'edit'}title="{ts}Edit{/ts}"{/if}>
+    <div class="crm-clear crm-inline-block-content" {if $permission EQ 'edit'}title="{ts escape='htmlattribute'}Edit{/ts}"{/if}>
       {if $permission EQ 'edit'}
         <div class="crm-edit-help">
           <span class="crm-i fa-pencil"></span> {ts}Edit{/ts}


### PR DESCRIPTION
Ensure translated strings don't inadvertently break out of the quotes or contain any unsupported characters.