### PR TITLE
Add smarty & php compatibility info

### DIFF
--- a/info.xml
+++ b/info.xml
@@ -20,6 +20,15 @@
   <compatibility>
     <ver>5.74</ver>
   </compatibility>
+  <smarty_compatibility>
+    <ver>5.0</ver>
+  </smarty_compatibility>
+  <php_compatibility>
+    <ver>8.1</ver>
+    <ver>8.2</ver>
+    <ver>8.3</ver>
+    <ver>8.4</ver>
+  </php_compatibility>
   <civix>
     <namespace>CRM/Contactlayout</namespace>
     <format>24.09.1</format>


### PR DESCRIPTION
As of ?6.0? this is visible in the UI - although it is not terribly obvious - the goal is to get it added to the extensions & then start to make it more prominent / add warnings.

As it is forward-looking I haven't added php 8.0 / old Smarty versions