### PR TITLE
Add support for layout settings and subtype operators.

### DIFF
--- a/CRM/Contactlayout/Upgrader.php
+++ b/CRM/Contactlayout/Upgrader.php
@@ -109,4 +109,16 @@ class CRM_Contactlayout_Upgrader extends CRM_Extension_Upgrader_Base {
     return TRUE;
   }
 
+  /**
+   * Add settings column.
+   *
+   * @return TRUE on success
+   * @throws Exception
+   */
+  public function upgrade_1004() {
+    $this->ctx->log->info('Applying update 1004 - Add settings column.');
+    CRM_Core_DAO::executeQuery("ALTER TABLE `civicrm_contact_layout` ADD COLUMN `settings` text COMMENT 'Extra configuration data for the layout.'");
+    return TRUE;
+  }
+
 }

--- a/ang/contactlayout/contactLayoutEditor.component.js
+++ b/ang/contactlayout/contactLayoutEditor.component.js
@@ -418,7 +418,8 @@
             contact_sub_type: layout.contact_sub_type?.length ? layout.contact_sub_type : null,
             groups: layout.groups?.length ? layout.groups : null,
             blocks: [],
-            tabs: layout.tabs ? [] : null
+            tabs: layout.tabs ? [] : null,
+            settings: layout.settings || {},
           };
 
           layout.blocks.forEach((row, rowNum) => {
@@ -516,6 +517,12 @@
 
       function loadLayout(layout) {
         layout.palette = _.cloneDeep(allBlocks);
+
+        if (!layout.settings || Array.isArray(layout.settings)) {
+          layout.settings = {};
+        }
+        layout.settings.sub_type_operator = layout.settings.sub_type_operator || 'OR';
+
         if (layout.tabs) {
           // Filter out tabs that no longer exist
           layout.tabs = layout.tabs.filter(item => allTabs[item.id]);

--- a/ang/contactlayout/contactlayout-canvas.html
+++ b/ang/contactlayout/contactlayout-canvas.html
@@ -3,13 +3,19 @@
     <form class="navbar-form navbar-left">
       <div class="form-group">
         <label for="selected_layout_contact_type">{{:: ts('Show:') }}</label>
-        <select id="selected_layout_contact_type" class="form-control" ng-model="selectedLayout.contact_type" crm-ui-select ng-change="changeContactType(selectedLayout)">
+        <select id="selected_layout_contact_type" class="form-control crm-auto-width" ng-model="selectedLayout.contact_type" crm-ui-select ng-change="changeContactType(selectedLayout)">
           <option value="">{{:: ts('Contact type') }}</option>
           <option ng-repeat="ct in contactTypes" value="{{ ct.name }}" ng-if="!ct.parent_id">{{ ct.label }}</option>
         </select>
         <span ng-if="selectedLayout.contact_type && selectableSubTypes(selectedLayout.contact_type).length">
           <select multiple placeholder="{{:: ts('Any subtype') }}" class="form-control" ng-model="selectedLayout.contact_sub_type" crm-ui-select>
             <option ng-repeat="ct in selectableSubTypes(selectedLayout.contact_type)" value="{{ ct.name }}">{{ ct.label }}</option>
+          </select>
+        </span>
+        <span ng-if="selectedLayout.contact_sub_type.length > 1">
+          <select ng-model="selectedLayout.settings.sub_type_operator" class="form-control crm-auto-width">
+            <option value="OR">{{:: ts('Any') }}</option>
+            <option value="AND">{{:: ts('All') }}</option>
           </select>
         </span>
         <label for="selected_layout_groups">{{:: ts('To:') }}</label>

--- a/schema/ContactLayout.entityType.php
+++ b/schema/ContactLayout.entityType.php
@@ -1,5 +1,6 @@
 <?php
 use CRM_Contactlayout_ExtensionUtil as E;
+
 return [
   'name' => 'ContactLayout',
   'table' => 'civicrm_contact_layout',
@@ -99,6 +100,14 @@ return [
       'input_type' => 'TextArea',
       'description' => E::ts('Contains json encoded layout tabs.'),
       'add' => '1.2',
+      'serialize' => constant('CRM_Core_DAO::SERIALIZE_JSON'),
+    ],
+    'settings' => [
+      'title' => E::ts('Layout Settings'),
+      'sql_type' => 'text',
+      'input_type' => 'TextArea',
+      'description' => E::ts('Extra configuration data for the layout.'),
+      'add' => '2.5',
       'serialize' => constant('CRM_Core_DAO::SERIALIZE_JSON'),
     ],
   ],


### PR DESCRIPTION
This commit introduces a `settings` column in the ContactLayout schema for additional layout configuration. It also adds a subtype operator selector (`Any`/`All`) in the UI, which is not yet functional.