### PR TITLE
Cleanup `<style>` tags by removing obsolete `type` attributes.

### DIFF
--- a/templates/CRM/Contactlayout/Page/Base.tpl
+++ b/templates/CRM/Contactlayout/Page/Base.tpl
@@ -8,7 +8,7 @@
 </div>
 {* Since css files don't support translatable strings *}
 {literal}
-  <style type="text/css">
+  <style>
     #cse-block-container .cse-layout-col .block-multiple:not(.collapsed):after {
       content: '+ {/literal}{ts}Multiple{/ts}{literal}';
     }


### PR DESCRIPTION
See https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/style#deprecated_attributes